### PR TITLE
Return EST timestamp via HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Building a Remote MCP Server on Cloudflare (Without Auth)
 
-This example allows you to deploy a remote MCP server that doesn't require authentication on Cloudflare Workers. 
+This example shows a simple Model Context Protocol (MCP) server that responds
+with the current time in the US Eastern timezone.  The server does **not**
+perform any authentication and accepts plain HTTP `GET` and `POST` requests.
 
 ## Get started: 
 


### PR DESCRIPTION
## Summary
- clarify README instructions
- simplify the worker to drop WebSocket support
- return current Eastern time on GET/POST

## Testing
- `npm test` *(fails: Missing script)*
- `npm run type-check` *(fails: ts errors)*

------
https://chatgpt.com/codex/tasks/task_e_685303fcd8788324a327da6c3c498f62