### PR TITLE
Implement minimal MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This example shows a simple Model Context Protocol (MCP) server that responds
 with the current time in the US Eastern timezone.  The server does **not**
-perform any authentication and accepts plain HTTP `GET` and `POST` requests.
+perform any authentication and exposes an SSE endpoint at `/sse`.
 
 ## Get started: 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,100 +1,51 @@
-// src/index.js  — ES-module Worker (no Durable Objects)
+import { McpAgent } from "agents/mcp";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
 
-// ── 1. Utility: ISO-8601 timestamp in America/New_York ───────────────
-function getEasternTime() {
-  const now  = new Date();
-  const fmt  = new Intl.DateTimeFormat('en-US', {
-    timeZone : 'America/New_York',
-    year     : 'numeric', month :'2-digit', day   :'2-digit',
-    hour     : '2-digit', minute:'2-digit', second:'2-digit',
-    hour12   : false
+// Utility to generate an ISO-8601 string in America/New_York
+function getEasternTime(): string {
+  const now = new Date();
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    timeZone: "America/New_York",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
   });
+  const parts = Object.fromEntries(fmt.formatToParts(now).map(p => [p.type, p.value]));
+  const date = `${parts.year}-${parts.month}-${parts.day}`;
+  const time = `${parts.hour}:${parts.minute}:${parts.second}`;
 
-  const parts = Object.fromEntries(fmt.formatToParts(now).map(o => [o.type, o.value]));
-  const date  = `${parts.year}-${parts.month}-${parts.day}`;
-  const time  = `${parts.hour}:${parts.minute}:${parts.second}`;
-
-  const offsetMin = new Date(now.toLocaleString('en-US', { timeZone: 'America/New_York' }))
-                      .getTimezoneOffset();             // minutes west of UTC
-  const sign = offsetMin <= 0 ? '+' : '-';
-  const abs  = Math.abs(offsetMin);
-  const hh   = String(Math.floor(abs / 60)).padStart(2, '0');
-  const mm   = String(abs % 60).padStart(2, '0');
+  const offset = new Date(now.toLocaleString("en-US", { timeZone: "America/New_York" })).getTimezoneOffset();
+  const sign = offset <= 0 ? "+" : "-";
+  const abs = Math.abs(offset);
+  const hh = String(Math.floor(abs / 60)).padStart(2, "0");
+  const mm = String(abs % 60).padStart(2, "0");
 
   return `${date}T${time}${sign}${hh}:${mm}`;
 }
 
-// ── 2. JSON-RPC helpers ──────────────────────────────────────────────
-const ok  = (id, result)        => ({ jsonrpc: '2.0', id, result });
-const err = (id, code, message) => ({ jsonrpc: '2.0', id, error: { code, message } });
-const PARSE_ERR = -32700, NOT_FOUND = -32601;
-
-// ── 3. Main request handler ──────────────────────────────────────────
-async function handleRequest(request) {
-  // Quick GET: /?method=get_eastern_time
-  if (request.method === 'GET') {
-    const m = new URL(request.url).searchParams.get('method');
-    if (m) {
-      const res = m === 'get_eastern_time'
-        ? getEasternTime()
-        : `Unknown method ${m}`;
-      return json(ok('mcp-id', res));
-    }
-  }
-
-  if (request.method !== 'POST')
-    return new Response('Use POST with JSON-RPC 2.0', { status: 405 });
-
-  let payload;
-  try { payload = await request.json(); }
-  catch { return json(err(null, PARSE_ERR, 'Parse error'), 400); }
-
-  const id = payload.id ?? 'mcp-id';
-  const { method, params } = payload;
-
-  // ── Supported methods ────────────────────────────────────────────
-  if (method === 'initialize')
-    return json(ok(id, {
-      protocolVersion: '2024-11-05',
-      serverInfo: {
-        name: 'eastern-time-server',
-        version: '1.0.0',
-        description: 'Provides Eastern Time ISO timestamps'
-      },
-      capabilities: {
-        tools: {
-          get_eastern_time: {
-            description: 'Returns ISO 8601 Eastern Time string',
-            inputSchema:  { type: 'object', properties: {}, additionalProperties: false },
-            outputFormat: 'string'
-          }
-        }
-      }
-    }));
-
-  if (method === 'tools/list')
-    return json(ok(id, {
-      tools: [{
-        name: 'get_eastern_time',
-        description: 'Get Eastern Time ISO string',
-        inputSchema:  { type: 'object', properties: {}, additionalProperties: false },
-        outputFormat: 'string'
-      }]
-    }));
-
-  if (method === 'tools/call' && params?.name === 'get_eastern_time')
-    return json(ok(id, getEasternTime()));
-
-  // Anything else
-  return json(err(id, NOT_FOUND, `Method not found: ${method}`));
-}
-
-// Helper to return JSON
-const json = (obj, status = 200) =>
-  new Response(JSON.stringify(obj), {
-    status,
-    headers: { 'Content-Type': 'application/json' }
+// Durable Object implementing our MCP server
+export class MyMCP extends McpAgent {
+  server = new McpServer({
+    name: "Eastern Time Server",
+    version: "1.0.0",
   });
 
-// ── 4. Export for Cloudflare Workers (module syntax) ─────────────────
-export default { fetch: handleRequest };
+  async init() {
+    this.server.tool(
+      "get_eastern_time",
+      z.object({}),
+      async () => ({ content: [{ type: "text", text: getEasternTime() }] })
+    );
+  }
+}
+
+export default {
+  fetch(request: Request, env: Env, ctx: ExecutionContext) {
+    return MyMCP.serve("/sse").fetch(request, env, ctx);
+  },
+};


### PR DESCRIPTION
## Summary
- use SSE endpoint for the MCP server
- implement a durable object `MyMCP` that provides a `get_eastern_time` tool

## Testing
- `npm run type-check` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_6853127dfa74832496278cf0fc32df0b